### PR TITLE
Authenticate like the Heroku CLI

### DIFF
--- a/heroku.go
+++ b/heroku.go
@@ -152,7 +152,7 @@ func (c *Client) NewRequest(method, path string, body interface{}) (*http.Reques
 	if ctype != "" {
 		req.Header.Set("Content-Type", ctype)
 	}
-	req.SetBasicAuth(c.Username, c.Password)
+	req.SetBasicAuth("", c.Password)
 	for k, v := range c.AdditionalHeaders {
 		req.Header[k] = v
 	}


### PR DESCRIPTION
This moves heroku.go over to the same authentication scheme as the
Heroku CLI, which allows intermediaries to recognize when equivalent
credentials are in use between different clients (say the CLI and hk for
example).

See heroku/hk#176 for more detailed information.

Thanks Blake!
