### PR TITLE
Remove deprecated Google Code import path

### DIFF
--- a/heroku.go
+++ b/heroku.go
@@ -18,7 +18,7 @@ import (
 	"runtime"
 	"strings"
 
-	"code.google.com/p/go-uuid/uuid"
+	"github.com/pborman/uuid"
 )
 
 const (


### PR DESCRIPTION
Fixes warning when running

``` console
$ go get github.com/bgentry/heroku-go
warning: code.google.com is shutting down; import path code.google.com/p/go-uuid/uuid will stop working
```
